### PR TITLE
Refactor line splitting to use array destructuring

### DIFF
--- a/lib/windows-shortcuts.js
+++ b/lib/windows-shortcuts.js
@@ -20,9 +20,8 @@ function parseQuery(stdout) {
 	stdout.split(/[\r\n]+/)
 		.filter(function(line) { return line.indexOf('=') !== -1; })
 		.forEach(function(line) {
-				var pair = line.split('=', 2),
-				key = pair[0],
-				value = pair[1];
+				var [key, ...value] = line.split('='),
+				value = value.join("=");
 				if (key === "TargetPath")
 					result.target = value;
 				else if (key === "TargetPathExpanded")


### PR DESCRIPTION
Fixes the bug when there're args with = in them.